### PR TITLE
feat: Restructure total statistics in report

### DIFF
--- a/src/reqstool/commands/report/templates/total_statistics.j2
+++ b/src/reqstool/commands/report/templates/total_statistics.j2
@@ -4,14 +4,14 @@
 
 [cols="0.5,1a"]
 |===
-|Total requirements ({{report.nr_of_total_requirements}})|
-!===
-!Completed ! Implemented ! Not Implemented 
+| Total Requirements: {{report.nr_of_total_requirements}}|
+!====
+!Implemented and Verified ! Implemented ! Not Implemented 
 !{{report.nr_of_completed_requirements}}
-!{{report.nr_of_reqs_with_implementation}}
+!{{report.nr_of_reqs_with_implementation - report.nr_of_completed_requirements}}
 !{{report.nr_of_total_requirements - report.nr_of_reqs_with_implementation}}
 !===
-| Total tests ({{report.nr_of_total_tests}}) |
+| Total Tests / SVCs: ( {{report.nr_of_total_tests}} / {{report.nr_of_total_svcs}} )|
 !===
 !Passed tests !Failed tests !Skipped tests !SVC's missing tests !SVCs missing MVRs  
 !{{report.nr_of_passed_tests}}

--- a/src/reqstool/commands/report/templates/total_statistics.j2
+++ b/src/reqstool/commands/report/templates/total_statistics.j2
@@ -13,11 +13,12 @@
 !===
 | Total tests ({{report.nr_of_total_tests}}) |
 !===
-!Passed tests !Failed tests !Skipped tests !Missing tests  
+!Passed tests !Failed tests !Skipped tests !SVC's missing tests !SVCs missing MVRs  
 !{{report.nr_of_passed_tests}}
 !{{report.nr_of_failed_tests}}
 !{{report.nr_of_skipped_tests}}
-!{{report.nr_of_missing_tests}}
+!{{report.nr_of_missing_automated_tests}}
+!{{report.nr_of_missing_manual_tests}}
 !===
 |===
 

--- a/src/reqstool/commands/status/statistics_container.py
+++ b/src/reqstool/commands/status/statistics_container.py
@@ -40,6 +40,7 @@ class TotalStatisticsItem:
     nr_of_completed_requirements: int = 0
     nr_of_total_requirements: int = 0
     nr_of_reqs_with_implementation: int = 0
+    nr_of_total_svcs: int = 0
 
     def update(self, completed: bool, combined_req_test_item: CombinedRequirementTestItem):
         self.nr_of_total_requirements += 1

--- a/src/reqstool/commands/status/statistics_generator.py
+++ b/src/reqstool/commands/status/statistics_generator.py
@@ -222,6 +222,9 @@ class StatisticsGenerator:
         # Total mvrs
         total_no_of_mvrs = len(self.cid.mvrs)
 
+        # Total SVCs
+        stats_container._total_statistics.nr_of_total_svcs = len(self.cid.svcs)
+
         # Combined
         stats_container._total_statistics.nr_of_total_tests = total_no_of_annotated_tests + total_no_of_mvrs
 

--- a/src/reqstool/commands/status/status.py
+++ b/src/reqstool/commands/status/status.py
@@ -66,6 +66,7 @@ def _status_table(stats_container: StatisticsContainer) -> str:
     table_with_title = f"{title}\n{table}\n"
     statisics = _summarize_statisics(
         nr_of_total_reqs=stats_container._total_statistics.nr_of_total_requirements,
+        nr_of_completed_reqs=stats_container._total_statistics.nr_of_completed_requirements,
         implemented=stats_container._total_statistics.nr_of_reqs_with_implementation,
         left_to_implement=stats_container._total_statistics.nr_of_total_requirements
         - stats_container._total_statistics.nr_of_reqs_with_implementation,
@@ -96,6 +97,7 @@ def _status_table(stats_container: StatisticsContainer) -> str:
 
 def _summarize_statisics(
     nr_of_total_reqs: int,
+    nr_of_completed_reqs: int,
     implemented: int,
     left_to_implement: int,
     total_tests: int,
@@ -105,11 +107,17 @@ def _summarize_statisics(
     missing_automated_tests: int,
     missing_manual_tests: int,
 ) -> str:
-    table_data = [
+    table_req_data = [
         [
             str(nr_of_total_reqs),
+            str(nr_of_completed_reqs)
+            + __numbers_as_percentage(numerator=nr_of_completed_reqs, denominator=nr_of_total_reqs),
             str(implemented) + __numbers_as_percentage(numerator=implemented, denominator=nr_of_total_reqs),
             str(left_to_implement) + __numbers_as_percentage(numerator=left_to_implement, denominator=nr_of_total_reqs),
+        ]
+    ]
+    table_svc_data = [
+        [
             str(passed_tests) + __numbers_as_percentage(numerator=passed_tests, denominator=total_tests),
             str(failed_tests) + __numbers_as_percentage(numerator=failed_tests, denominator=total_tests),
             str(skipped_tests) + __numbers_as_percentage(numerator=skipped_tests, denominator=total_tests),
@@ -123,19 +131,27 @@ def _summarize_statisics(
             ),
         ]
     ]
-    headers = [
+    req_headers = [
         "Total requirements",
+        "Completed requirements",
         "Implemented",
         "Not implemented",
+    ]
+    svc_headers = [
         "Passed tests",
         "Failing tests",
         "Skipped tests",
         "SVCs missing tests",
         "SVCs missing MVRs",
     ]
-    col_align = ["center"] * len(table_data[0])
-    table = table = tabulate(tablefmt="fancy_grid", tabular_data=table_data, headers=headers, colalign=col_align)
-    table_with_title = f"\n{table}"
+    col_align = ["center"] * len(table_req_data[0])
+    req_table = req_table = tabulate(
+        tablefmt="fancy_grid", tabular_data=table_req_data, headers=req_headers, colalign=col_align
+    )
+    svc_table = svc_table = tabulate(
+        tablefmt="fancy_grid", tabular_data=table_svc_data, headers=svc_headers, colalign=col_align
+    )
+    table_with_title = f"\n{req_table}\n{svc_table}"
 
     return table_with_title
 

--- a/tests/unit/reqstool/commands/status/test_statistics_generator.py
+++ b/tests/unit/reqstool/commands/status/test_statistics_generator.py
@@ -121,6 +121,7 @@ def test_calculate_test_basic(local_testdata_resources_rootdir_w_path):
             nr_of_completed_requirements=2,
             nr_of_total_requirements=4,
             nr_of_reqs_with_implementation=2,
+            nr_of_total_svcs=4,
         ),
     )
     assert result == expected


### PR DESCRIPTION
Restructure the total statistics generated in the report.

Divide statistics into two rows.

One table row for Requirements with:

* total
* verified (all tests passed)
* implemented
* not implemented

Another table row for tests and SVC's:

* Passed
* Failed
* Skipped
* (Total number of SVC's)?
* SVC's missing automated tests
* SVC's missing manual tests(MVR)