### PR TITLE
Fix python support

### DIFF
--- a/docs/modules/ROOT/pages/file_and_directory_set.adoc
+++ b/docs/modules/ROOT/pages/file_and_directory_set.adoc
@@ -36,9 +36,9 @@ Below is an example on how to change the default paths to the required *.yml fil
 
 type: custom 
 locations:
-  test_results:
-    failsafe: ../target/some_folder/failsafe
-    surefire: ../target/my_folder/surefire
+  test_results_dirs:
+    - ../target/some_folder/failsafe
+    - ../target/my_folder/surefire
   annotations:
     implementations: ../target/hello/requirements_annotations_impls.yml
     tests: ../target/demo/requirements_annotations_tests.yml

--- a/docs/modules/ROOT/pages/yml/reqstool_config.adoc
+++ b/docs/modules/ROOT/pages/yml/reqstool_config.adoc
@@ -8,9 +8,9 @@
 type: custom # custom|java-maven|java-maven-docs|python-pyproject
 
 locations:
-  test_results:
-    failsafe: target/failsafe
-    surefire: target/surefire
+  test_results_dirs:
+    - target/failsafe
+    - target/surefire
   annotations:
     implementations: requirements_annotations_impls.yml
     tests: requirements_annotations_tests.yml

--- a/docs/modules/examples/partials/requirements/reqstool_config.yml
+++ b/docs/modules/examples/partials/requirements/reqstool_config.yml
@@ -3,9 +3,9 @@
 type: custom # custom|java-maven|java-maven-docs|python-pyproject
 
 locations:
-  test_results:
-    failsafe: target/failsafe
-    surefire: target/surefire
+  test_results_dirs:
+    - target/failsafe
+    - target/surefire
   annotations:
     implementations: requirements_annotations_impls.yml
     tests: requirements_annotations_tests.yml

--- a/src/reqstool/model_generators/combined_raw_datasets_generator.py
+++ b/src/reqstool/model_generators/combined_raw_datasets_generator.py
@@ -219,19 +219,12 @@ class CombinedRawDatasetsGenerator:
 
         # handle automated test results
 
-        if requirements_indata.requirements_indata_paths.test_results_failsafe_dir.exists:
-            automated_tests_failsafe = TestDataModelGenerator(
-                path=requirements_indata.requirements_indata_paths.test_results_failsafe_dir.path, urn=current_urn
-            ).model
+        for test_results_dir in requirements_indata.requirements_indata_paths.test_results_dirs:
 
-            tests |= automated_tests_failsafe.tests
+            if test_results_dir.exists:
+                automated_tests_results = TestDataModelGenerator(path=test_results_dir.path, urn=current_urn).model
 
-        if requirements_indata.requirements_indata_paths.test_results_surefire_dir.exists:
-            automated_tests_surefire = TestDataModelGenerator(
-                path=requirements_indata.requirements_indata_paths.test_results_surefire_dir.path, urn=current_urn
-            ).model
-
-            tests |= automated_tests_surefire.tests
+                tests |= automated_tests_results.tests
 
         automated_tests = TestsData(tests=tests)
 

--- a/src/reqstool/model_generators/testdata_model_generator.py
+++ b/src/reqstool/model_generators/testdata_model_generator.py
@@ -34,7 +34,7 @@ class TestDataModelGenerator:
             tree = ET.parse(xml_file)
             root = tree.getroot()
 
-            for testcase in root.findall("./testcase"):
+            for testcase in root.findall(".//testcase"):
                 # Check if there is a match
                 match_unit = re.match(self.UNIT_METHOD_IDENTIFIER_REGEX, testcase.attrib["name"])
                 match_karate = re.match(self.KARATE_METHOD_IDENTIFIER_REGEX, testcase.attrib["name"])

--- a/src/reqstool/model_generators/testdata_model_generator.py
+++ b/src/reqstool/model_generators/testdata_model_generator.py
@@ -28,7 +28,7 @@ class TestDataModelGenerator:
     def __parse_test_data(self, path: str, urn: str) -> Dict[str, TestData]:
         r_testdata: Dict[str, TestData] = {}
 
-        xml_files = list(Path(path).glob("*.xml"))
+        xml_files = list(Path(path).glob("**/*.xml"))
 
         for xml_file in xml_files:
             tree = ET.parse(xml_file)

--- a/src/reqstool/reqstool_config/reqstool_config.py
+++ b/src/reqstool/reqstool_config/reqstool_config.py
@@ -1,25 +1,20 @@
 # Copyright © LFV
 
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from enum import Enum, unique
-from typing import Optional
+from typing import List, Optional
 
 
 @unique
 class TYPES(Enum):
     DEFAULT = "default"
     JAVA_MAVEN = "java-maven"
-
-
-@dataclass
-class TestResults:
-    failsafe: Optional[str] = None
-    surefire: Optional[str] = None
+    PYTHON = "python"
 
 
 @dataclass
 class Locations:
-    test_results: TestResults
+    test_results: List[str] = field(default_factory=lambda: [])
     annotations: Optional[str] = None
 
 
@@ -35,25 +30,18 @@ class ReqstoolConfig:
 
         r_project_root_dir = "." if "project_root_dir" not in yaml_data else yaml_data["project_root_dir"]
 
-        r_locations = Locations(annotations=None, test_results=TestResults())
+        r_locations = Locations(annotations=None, test_results=[])
 
-        if "locations" not in yaml_data:
-            return ReqstoolConfig(type=r_type, project_root_dir=r_project_root_dir, locations=r_locations)
+        if "locations" in yaml_data:
 
-        locations = yaml_data["locations"]
+            locations = yaml_data["locations"]
 
-        if "annotations" in locations:
-            annotations = locations["annotations"]
+            if "annotations" in locations:
+                annotations = locations["annotations"]
 
-            r_locations.annotations = annotations
+                r_locations.annotations = annotations
 
-        if "test_results" in locations:
-            test_results = locations["test_results"]
-
-            if "failsafe" in test_results:
-                r_locations.test_results.failsafe = test_results["failsafe"]
-
-            if "surefire" in test_results:
-                r_locations.test_results.surefire = test_results["surefire"]
+            if "test_results_dirs" in locations:
+                r_locations.test_results = locations["test_results_dirs"]
 
         return ReqstoolConfig(type=r_type, project_root_dir=r_project_root_dir, locations=r_locations)

--- a/src/reqstool/requirements_indata/python/python_requirements_indata_paths.py
+++ b/src/reqstool/requirements_indata/python/python_requirements_indata_paths.py
@@ -5,14 +5,17 @@ from dataclasses import dataclass
 from reqstool.requirements_indata.requirements_indata_paths import RequirementsIndataPathItem, RequirementsIndataPaths
 
 
+@dataclass(kw_only=True, frozen=True)
+class RequirementsIndataPathItem:
+    path: str
+    exists: bool = False
+
+
 @dataclass(kw_only=True)
-class JavaMavenRequirementsIndataPaths(RequirementsIndataPaths):
+class PythonRequirementsIndataPaths(RequirementsIndataPaths):
     def __init__(self):
         super().__init__()
 
         self.annotations_yml = RequirementsIndataPathItem(path="target/reqstool/annotations.yml")
 
-        self.test_results_dirs = [
-            RequirementsIndataPathItem(path="target/failfire-reports"),
-            RequirementsIndataPathItem(path="target/surefire-reports"),
-        ]
+        self.test_results_dirs = [RequirementsIndataPathItem(path="build/junit.xml")]

--- a/src/reqstool/requirements_indata/python/python_requirements_indata_paths.py
+++ b/src/reqstool/requirements_indata/python/python_requirements_indata_paths.py
@@ -5,17 +5,11 @@ from dataclasses import dataclass
 from reqstool.requirements_indata.requirements_indata_paths import RequirementsIndataPathItem, RequirementsIndataPaths
 
 
-@dataclass(kw_only=True, frozen=True)
-class RequirementsIndataPathItem:
-    path: str
-    exists: bool = False
-
-
 @dataclass(kw_only=True)
 class PythonRequirementsIndataPaths(RequirementsIndataPaths):
     def __init__(self):
         super().__init__()
 
-        self.annotations_yml = RequirementsIndataPathItem(path="target/reqstool/annotations.yml")
+        self.annotations_yml = RequirementsIndataPathItem(path="build/reqstool/annotations.yml")
 
         self.test_results_dirs = [RequirementsIndataPathItem(path="build/junit.xml")]

--- a/src/reqstool/requirements_indata/requirements_indata.py
+++ b/src/reqstool/requirements_indata/requirements_indata.py
@@ -2,7 +2,9 @@
 
 import os
 import sys
+from collections.abc import Sequence
 from dataclasses import dataclass, field, fields
+from typing import List, Union
 
 from ruamel.yaml import YAML
 
@@ -14,27 +16,21 @@ from reqstool.locations.local_location import LocalLocation
 from reqstool.locations.location import LocationInterface
 from reqstool.locations.maven_location import MavenLocation
 from reqstool.reqstool_config.reqstool_config import TYPES, ReqstoolConfig
-from reqstool.requirements_indata.java.java_maven_requirements_indata_paths import (
-    JavaMavenRequirementsIndataPaths,
-    RequirementsIndataPathItem,
-)
-from reqstool.requirements_indata.requirements_indata_paths import (
-    RequirementsIndataPaths,
-    RequirementsIndataStructureItem,
-)
+from reqstool.requirements_indata.java.java_maven_requirements_indata_paths import JavaMavenRequirementsIndataPaths
+from reqstool.requirements_indata.python.python_requirements_indata_paths import PythonRequirementsIndataPaths
+from reqstool.requirements_indata.requirements_indata_paths import RequirementsIndataPathItem, RequirementsIndataPaths
 
 
 @dataclass(kw_only=True)
 class RequirementsIndata:
     dst_path: str  # tmp path
     location: LocationInterface  # current location
-    reqstool_config: ReqstoolConfig = field(default=None)
+    reqstool_config: ReqstoolConfig = field(init=False, default=None)
     requirements_indata_paths: RequirementsIndataPaths = field(default_factory=RequirementsIndataPaths)
 
     def __post_init__(self):
         self._handle_requirements_config()
-        self._ensure_absolute_paths()
-        self._check_what_indata_that_exists()
+        self._ensure_absolute_paths_and_check_existance()
 
     def _handle_requirements_config(self):
 
@@ -55,42 +51,56 @@ class RequirementsIndata:
             match self.reqstool_config.type:
                 case TYPES.JAVA_MAVEN:
                     self.requirements_indata_paths = JavaMavenRequirementsIndataPaths()
+                case TYPES.PYTHON:
+                    self.requirements_indata_paths = PythonRequirementsIndataPaths()
 
             self._handle_custom()
 
             if self.reqstool_config.project_root_dir is not None:
                 self.requirements_indata_paths.prepend_paths(self.reqstool_config.project_root_dir)
 
-    def _ensure_absolute_paths(self):
+    def _ensure_absolute_paths_and_check_existance(self):
         # iterate over all fields and ensure absolute paths
 
         for f in fields(self.requirements_indata_paths):
             field_name = f.name
-            original_item: RequirementsIndataPathItem = getattr(self.requirements_indata_paths, field_name)
-            transformed_value = None
+            original: Union[RequirementsIndataPathItem, List[RequirementsIndataPathItem]] = getattr(
+                self.requirements_indata_paths, field_name
+            )
 
             if isinstance(self.location, GitLocation):
                 # Include self.location.path when resolving a git repository
-                transformed_value = os.path.abspath(os.path.join(self.dst_path, self.location.path, original_item.path))
+                RequirementsIndata._ensure_absolute_path_and_check_existance(
+                    paths=[self.dst_path, self.location.path], original=original
+                )
             elif isinstance(self.location, MavenLocation):
                 # Include self.location.path when resolving a git repository
-                transformed_value = os.path.abspath(os.path.join(self.dst_path, self.location.path, original_item.path))
+                RequirementsIndata._ensure_absolute_path_and_check_existance(
+                    paths=[self.dst_path, self.location.path], original=original
+                )
             elif isinstance(self.location, LocalLocation):
                 # resolve soft link
                 abs_dst_path = os.readlink(self.dst_path)
-                transformed_value = os.path.abspath(os.path.join(abs_dst_path, original_item.path))
+                RequirementsIndata._ensure_absolute_path_and_check_existance(paths=[abs_dst_path], original=original)
             else:
                 raise TypeError
 
-            original_item.path = transformed_value
+    def _ensure_absolute_path_and_check_existance(
+        paths: List[str], original: Union[RequirementsIndataPathItem, List[RequirementsIndataPathItem]]
+    ):
 
-    def _check_what_indata_that_exists(self):
-        # iterate over all fields and check for existance
+        if isinstance(original, RequirementsIndataPathItem):
+            new_abs_path = os.path.abspath(os.path.join(*paths, original.path))
+            original.path = new_abs_path
+            original.exists = os.path.exists(original.path)
 
-        for f in fields(self.requirements_indata_paths):
-            field_name = f.name
-            original_item: RequirementsIndataPathItem = getattr(self.requirements_indata_paths, field_name)
-            original_item.exists = os.path.exists(original_item.path)
+        elif isinstance(original, Sequence):
+            for item in original:
+                new_abs_path = os.path.abspath(os.path.join(*paths, item.path))
+                item.path = new_abs_path
+                item.exists = os.path.exists(item.path)
+        else:
+            raise TypeError(type(original))
 
     def _handle_custom(self):
         # replace default values with custom if specified
@@ -98,18 +108,15 @@ class RequirementsIndata:
         if self.reqstool_config.locations:
             test_results = self.reqstool_config.locations.test_results
 
-            if test_results:
-                if test_results.failsafe:
-                    self.requirements_indata_paths.test_results_failsafe_dir = RequirementsIndataStructureItem(
-                        path=test_results.failsafe
-                    )
+            if isinstance(test_results, Sequence):
+                r_test_results = []
 
-                if test_results.surefire:
-                    self.requirements_indata_paths.test_results_surefire_dir = RequirementsIndataStructureItem(
-                        path=test_results.surefire
-                    )
+                for test_result_dir in test_results:
+                    r_test_results.append(RequirementsIndataPathItem(path=test_result_dir))
+
+                self.requirements_indata_paths.test_results_dirs = r_test_results
 
             if self.reqstool_config.locations.annotations:
-                self.requirements_indata_paths.annotations_yml = RequirementsIndataStructureItem(
+                self.requirements_indata_paths.annotations_yml = RequirementsIndataPathItem(
                     path=self.reqstool_config.locations.annotations
                 )

--- a/src/reqstool/requirements_indata/requirements_indata_paths.py
+++ b/src/reqstool/requirements_indata/requirements_indata_paths.py
@@ -2,10 +2,11 @@
 
 from dataclasses import dataclass, field
 from pathlib import PurePath
+from typing import List
 
 
 @dataclass(kw_only=True)
-class RequirementsIndataStructureItem:
+class RequirementsIndataPathItem:
     path: str
     exists: bool = False
 
@@ -13,33 +14,30 @@ class RequirementsIndataStructureItem:
 @dataclass(kw_only=True)
 class RequirementsIndataPaths:
     # static
-    requirements_yml: RequirementsIndataStructureItem = field(
-        default_factory=lambda: RequirementsIndataStructureItem(path="requirements.yml")
+    requirements_yml: RequirementsIndataPathItem = field(
+        default_factory=lambda: RequirementsIndataPathItem(path="requirements.yml")
     )
 
-    svcs_yml: RequirementsIndataStructureItem = field(
-        default_factory=lambda: RequirementsIndataStructureItem(path="software_verification_cases.yml")
+    svcs_yml: RequirementsIndataPathItem = field(
+        default_factory=lambda: RequirementsIndataPathItem(path="software_verification_cases.yml")
     )
-    mvrs_yml: RequirementsIndataStructureItem = field(
-        default_factory=lambda: RequirementsIndataStructureItem(path="manual_verification_results.yml")
+    mvrs_yml: RequirementsIndataPathItem = field(
+        default_factory=lambda: RequirementsIndataPathItem(path="manual_verification_results.yml")
     )
 
     # dynamic
-    annotations_yml: RequirementsIndataStructureItem = field(
-        default_factory=lambda: RequirementsIndataStructureItem(path="annotations.yml")
+    annotations_yml: RequirementsIndataPathItem = field(
+        default_factory=lambda: RequirementsIndataPathItem(path="annotations.yml")
     )
-    test_results_failsafe_dir: RequirementsIndataStructureItem = field(
-        default_factory=lambda: RequirementsIndataStructureItem(path="test_results/failsafe")
-    )
-    test_results_surefire_dir: RequirementsIndataStructureItem = field(
-        default_factory=lambda: RequirementsIndataStructureItem(path="test_results/surefire")
+    test_results_dirs: List[RequirementsIndataPathItem] = field(
+        default_factory=lambda: [RequirementsIndataPathItem(path="test_results")]
     )
 
     def prepend_paths(self, prepend_dir):
         for prop in dir(self):
             if (
                 not prop.startswith("__")
-                and isinstance(getattr(self, prop), RequirementsIndataStructureItem)
+                and isinstance(getattr(self, prop), RequirementsIndataPathItem)
                 and prop not in ["requirements_yml", "svcs_yml", "mvrs_yml"]
             ):
                 path_item = getattr(self, prop)

--- a/src/reqstool/resources/schemas/v1/reqstool_config.schema.json
+++ b/src/reqstool/resources/schemas/v1/reqstool_config.schema.json
@@ -18,17 +18,11 @@
     "locations": {
       "type": "object",
       "properties": {
-        "test_results": {
-          "type": "object",
-          "properties": {
-            "failsafe": {
-              "type": "string",
-              "description": "Path to Failsafe test results"
-            },
-            "surefire": {
-              "type": "string",
-              "description": "Path to Surefire test results"
-            }
+        "test_results_dirs": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "description": "Path to test result directory"
           },
           "additionalProperties": false,
           "description": "Paths to test results directories"

--- a/tests/resources/test_data/data/local/test_basic/with_requirements_config/ms-101/reqstool_config.yml
+++ b/tests/resources/test_data/data/local/test_basic/with_requirements_config/ms-101/reqstool_config.yml
@@ -6,6 +6,6 @@ project_root_dir: "../../baseline/ms-101-maven"
 
 locations:
   annotations: annotations.yml
-  test_results:
-    failsafe: target/failsafe
-    surefire: target/surefire
+  test_results_dirs:
+    - target/failsafe
+    - target/surefire

--- a/tests/unit/reqstool/model_generators/test_testdata_model_generator.py
+++ b/tests/unit/reqstool/model_generators/test_testdata_model_generator.py
@@ -32,9 +32,11 @@ def test_unit_method_identifier_regex(method_name):
     assert unit_match.group(1) == "testFlightIdAircraftId"
 
 
-@pytest.mark.skip(reason="Awaiting testdata update")
-def test_testdata_model_generator():
+def test_testdata_model_generator(local_testdata_resources_rootdir_w_path):
     # TODO:
     # * Test the different variants: passed, skipped, failure etc
     # * Test different types of file structure (Java, Python, Frontend Typescript)
-    pass
+
+    tdmg = (
+        TestDataModelGenerator(path=local_testdata_resources_rootdir_w_path("test_basic/baseline/ms-101"), urn="test"),
+    )

--- a/tests/unit/reqstool/model_generators/test_testdata_model_generator.py
+++ b/tests/unit/reqstool/model_generators/test_testdata_model_generator.py
@@ -40,3 +40,5 @@ def test_testdata_model_generator(local_testdata_resources_rootdir_w_path):
     tdmg = (
         TestDataModelGenerator(path=local_testdata_resources_rootdir_w_path("test_basic/baseline/ms-101"), urn="test"),
     )
+
+    assert tdmg is not None

--- a/tests/unit/reqstool/reqstool_config/test_reqstool_config.py
+++ b/tests/unit/reqstool/reqstool_config/test_reqstool_config.py
@@ -16,10 +16,10 @@ def rc_yaml_config_all() -> dict:
     project_root_dir: /some_root_dir
 
     locations:
-        annotations: custom_annotations.yml
-        test_results:
-            failsafe: target/failsafe
-            surefire: target/surefire
+      annotations: custom_annotations.yml
+      test_results_dirs:
+        - target/failsafe
+        - target/surefire
     """
     yaml = YAML(typ="safe")
     data = yaml.load(YAML_STR)
@@ -55,8 +55,8 @@ def test_all(rc_yaml_config_all):
     assert rc.type == TYPES.JAVA_MAVEN
     assert rc.project_root_dir == "/some_root_dir"
     assert rc.locations.annotations == "custom_annotations.yml"
-    assert rc.locations.test_results.failsafe == "target/failsafe"
-    assert rc.locations.test_results.surefire == "target/surefire"
+    assert rc.locations.test_results[0] == "target/failsafe"
+    assert rc.locations.test_results[1] == "target/surefire"
 
 
 def test_minimal(rc_yaml_config_minimal):

--- a/tests/unit/reqstool/requirements_indata/test_requirements_indata_paths.py
+++ b/tests/unit/reqstool/requirements_indata/test_requirements_indata_paths.py
@@ -36,18 +36,19 @@ def test_prepend_paths_with_none_properties(default_instance):
     assert a.svcs_yml.path == b.svcs_yml.path
     assert a.mvrs_yml.path == b.mvrs_yml.path
     assert a.annotations_yml.path == str(PurePath(prepend_str, b.annotations_yml.path))
-    assert a.test_results_failsafe_dir.path == str(PurePath(prepend_str, b.test_results_failsafe_dir.path))
-    assert a.test_results_surefire_dir.path == str(PurePath(prepend_str, b.test_results_surefire_dir.path))
+    assert len(a.test_results_dirs) == 1
 
 
 # Test the merge method with properties that can be None
 def test_merge_with_none_properties(default_instance, java_instance):
     java_instance.ra_tests_yml = None
-    merged_instance = default_instance.merge(java_instance)
+    java_merged_instance = default_instance.merge(java_instance)
 
-    assert merged_instance.requirements_yml.path == "requirements.yml"
-    assert merged_instance.svcs_yml.path == "software_verification_cases.yml"
-    assert merged_instance.mvrs_yml.path == "manual_verification_results.yml"
-    assert merged_instance.annotations_yml.path == "target/reqstool/annotations.yml"
-    assert merged_instance.test_results_failsafe_dir.path == "target/failsafe-reports"
-    assert merged_instance.test_results_surefire_dir.path == "target/surefire-reports"
+    assert java_merged_instance.requirements_yml.path == "requirements.yml"
+    assert java_merged_instance.svcs_yml.path == "software_verification_cases.yml"
+    assert java_merged_instance.mvrs_yml.path == "manual_verification_results.yml"
+    assert java_merged_instance.annotations_yml.path == "target/reqstool/annotations.yml"
+    assert len(java_merged_instance.test_results_dirs) == 2
+
+    expected_paths = ["target/failfire-reports", "target/surefire-reports"]
+    assert all(item.path in expected_paths for item in java_merged_instance.test_results_dirs)


### PR DESCRIPTION
This PR will add fixes to that reqstool works with python projects

1. Added reqstool_config.yml defaults for python #43
2. Added support for pytest2 junit reports xml files #44
 
 Closes #43 #44 