### PR TITLE
ci: Install reqstool-client from build and run status command

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -32,6 +32,11 @@ jobs:
         run: hatch run test:pytest --cov=reqstool-client --cov-report=xml --cov-report=html -o junit_family=xunit2 --junitxml=build/junit.xml
       - name: Build project
         run: hatch build
+      - name: Install and run reqstool-client from build
+        run: |
+          WHL_FILE=$(ls dist/*.whl)
+          pip install $WHL_FILE
+          reqstool status local -p docs/reqstool
       # Upload artifacts for later use
       - name: Upload Artifacts
         uses: actions/upload-artifact@v4

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -32,7 +32,7 @@ jobs:
         run: hatch run test:pytest --cov=reqstool-client --cov-report=xml --cov-report=html -o junit_family=xunit2 --junitxml=build/junit.xml
       - name: Build project
         run: hatch build
-      - name: Install and run reqstool-client from build
+      - name: Test reqstool-client from build by installing and running
         run: |
           WHL_FILE=$(ls dist/*.whl)
           pip install $WHL_FILE

--- a/tests/unit/reqstool/model_generators/test_combined_raw_datasets_generator.py
+++ b/tests/unit/reqstool/model_generators/test_combined_raw_datasets_generator.py
@@ -72,6 +72,7 @@ def test_standard_sys001_initial(local_testdata_resources_rootdir_w_path):
     )
 
 
+@SVCs("SVC_020")
 def test_missing_requirements_file(local_testdata_resources_rootdir_w_path):
     with pytest.raises(SystemExit) as excinfo:
         semantic_validator = SemanticValidator(validation_error_holder=ValidationErrorHolder())


### PR DESCRIPTION
This PR adds a step to the build workflow where reqstool is installed from the built wheel image and runs the status command towards the requirements on reqstool-client.  