### PR TITLE
feat: Fixes resolving of paths and bugs related to finding testdata

### DIFF
--- a/docs/reqstool/reqstool_config.yml
+++ b/docs/reqstool/reqstool_config.yml
@@ -5,4 +5,4 @@ project_root_dir: "../.."
 locations:
   annotations: "build/reqstool/annotations.yml"
   test_results_dirs:
-    - "../../build/"
+    - "build/"

--- a/src/reqstool/requirements_indata/java/java_maven_requirements_indata_paths.py
+++ b/src/reqstool/requirements_indata/java/java_maven_requirements_indata_paths.py
@@ -13,6 +13,6 @@ class JavaMavenRequirementsIndataPaths(RequirementsIndataPaths):
         self.annotations_yml = RequirementsIndataPathItem(path="target/reqstool/annotations.yml")
 
         self.test_results_dirs = [
-            RequirementsIndataPathItem(path="target/failfire-reports"),
+            RequirementsIndataPathItem(path="target/failsafe-reports"),
             RequirementsIndataPathItem(path="target/surefire-reports"),
         ]

--- a/src/reqstool/requirements_indata/requirements_indata.py
+++ b/src/reqstool/requirements_indata/requirements_indata.py
@@ -107,7 +107,7 @@ class RequirementsIndata:
     def _handle_custom(self):
         # replace default values with custom if specified
 
-        if self.reqstool_config.locations:
+        if self.reqstool_config.locations.test_results:
             test_results = self.reqstool_config.locations.test_results
 
             if isinstance(test_results, Sequence):
@@ -118,7 +118,7 @@ class RequirementsIndata:
 
                 self.requirements_indata_paths.test_results_dirs = r_test_results
 
-            if self.reqstool_config.locations.annotations:
-                self.requirements_indata_paths.annotations_yml = RequirementsIndataPathItem(
-                    path=self.reqstool_config.locations.annotations
-                )
+        if self.reqstool_config.locations.annotations:
+            self.requirements_indata_paths.annotations_yml = RequirementsIndataPathItem(
+                path=self.reqstool_config.locations.annotations
+            )

--- a/src/reqstool/requirements_indata/requirements_indata_paths.py
+++ b/src/reqstool/requirements_indata/requirements_indata_paths.py
@@ -1,9 +1,8 @@
 # Copyright © LFV
 
-import logging
 from dataclasses import dataclass, field
 from pathlib import PurePath
-from typing import List
+from typing import List, Union
 
 from reqstool_python_decorators.decorators.decorators import Requirements
 
@@ -47,19 +46,42 @@ class RequirementsIndataPaths:
                 path_item = getattr(self, prop)
                 self.check_type_and_prepend_path(path_item=path_item, prepend_dir=prepend_dir)
 
-    # prepend path for each entry in a list of RequirementsIndataPathItem(s) or just on a single entity of the class
-    def check_type_and_prepend_path(self, path_item, prepend_dir: str):
+    def check_type_and_prepend_path(
+        self, path_item: Union[RequirementsIndataPathItem, List[RequirementsIndataPathItem]], prepend_dir: str
+    ):
+        """Prepend path for each entry in a list of RequirementsIndataPathItem(s)
+           or just on a single entity of the class
+
+        Args:
+            path_item (RequirementsIndataPathItem, [RequirementsIndataPathItem]): Either a RequirementsIndataPathItem
+            or a list of RequirementsIndataPathItem
+            prepend_dir (str): the root dir of the project specified in the reqstool_config.yml.
+
+        Raises:
+            TypeError: if there is a mismatch with path_item type or a path of a RequirementsIndataPathItem is missing.
+        """
         if type(path_item) is list:
             for entry in path_item:
-                if type(entry) is RequirementsIndataPathItem and entry.path is not None:
+                if entry.path is not None:
                     entry.path = str(PurePath(prepend_dir, entry.path))
-                else:
-                    logging.error("Cannot prepend path on object of type: " + type(entry))
         else:
             if path_item.path is not None:
                 path_item.path = str(PurePath(prepend_dir, path_item.path))
 
-    # other has precedence
+    def check_type_and_prepend_path2(self, path_item, prepend_dir: str):
+        if isinstance(path_item, list):
+            path_item = [
+                (
+                    entry
+                    if entry is None or entry.path is None
+                    else entry._replace(path=str(PurePath(prepend_dir, entry.path)))
+                )
+                for entry in path_item
+            ]
+        elif path_item is not None and path_item.path is not None:
+            path_item.path = str(PurePath(prepend_dir, path_item.path))
+        return path_item
+
     def merge(self, other):
         merged_instance = self.__class__()
         for prop in dir(self):
@@ -72,11 +94,9 @@ class RequirementsIndataPaths:
 
     def attribute_is_instance_or_list_of_class(self, prop_name, the_class):
         prop = getattr(self, prop_name)
-        if isinstance(prop, the_class):  # Check if the prop is an instance of the class
+        if isinstance(prop, the_class):
             return True
-        elif isinstance(prop, list):  # Check if the prop is a list
-            return all(
-                isinstance(item, the_class) for item in prop
-            )  # Check if all items in the list are instances of the class
+        elif isinstance(prop, list):
+            return all(isinstance(item, the_class) for item in prop)
         else:
             return False

--- a/tests/unit/reqstool/requirements_indata/test_requirements_indata_paths.py
+++ b/tests/unit/reqstool/requirements_indata/test_requirements_indata_paths.py
@@ -50,5 +50,5 @@ def test_merge_with_none_properties(default_instance, java_instance):
     assert java_merged_instance.annotations_yml.path == "target/reqstool/annotations.yml"
     assert len(java_merged_instance.test_results_dirs) == 2
 
-    expected_paths = ["target/failfire-reports", "target/surefire-reports"]
+    expected_paths = ["target/failsafe-reports", "target/surefire-reports"]
     assert all(item.path in expected_paths for item in java_merged_instance.test_results_dirs)


### PR DESCRIPTION
This MR corrects the logic with prepending paths if the user has specified them in the reqstool_config. It also adresses an spelling error and the logic in the handle_custom() function that rewrote the default paths of maven and python projects to an empty list. 