### PR TITLE
feat: Updates permissions and adds usage example

### DIFF
--- a/.github/workflows/release_prod.yml
+++ b/.github/workflows/release_prod.yml
@@ -1,6 +1,7 @@
 name: Build and publish to PyPI
 
 on:
+  workflow_dispatch:
   release:
     types: [created]
 
@@ -35,6 +36,7 @@ jobs:
           sign-artifacts: true
 
   publish-image-to-ghcr:
+    if: github.event_name == 'release' || github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-latest
     permissions:
       contents: read

--- a/.github/workflows/release_prod.yml
+++ b/.github/workflows/release_prod.yml
@@ -11,10 +11,9 @@ jobs:
   build:
     name: Reuse build
     uses: ./.github/workflows/build.yml
-  
 
   publish-to-pypi:
-    needs: 
+    needs:
       - check-release
       - build
     runs-on: ubuntu-latest
@@ -37,6 +36,9 @@ jobs:
 
   publish-image-to-ghcr:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
     needs:
       - publish-to-pypi
     steps:
@@ -59,4 +61,3 @@ jobs:
           context: .
           push: true
           tags: ghcr.io/${{ github.repository_owner }}/reqstool:latest
-          

--- a/docs/modules/ROOT/pages/usage.adoc
+++ b/docs/modules/ROOT/pages/usage.adoc
@@ -86,3 +86,10 @@ reqstool report-asciidoc local -p path_to_requirements_dir -o path_to_output_fil
 Note: There is currently no JSON Schema for this file and it is a raw dump of the data structures using [jsonpickle](https://github.com/jsonpickle/jsonpickle) the format might change at anytime for the time being.
 
 
+=== Using the Docker image
+
+You could also run Reqstool-client from a container, using the same commands as above. However, you will also need to mount the path to the indata and/or where the expected output file should be placed. Below is an example using the `report-asciidoc` command once you have either built the image yourself or pulled it from ghcr.
+
+```bash
+docker run --rm -v path_to_requirements_files_folder:/input -v path_to_output_folder:/output  <containerId/tag> sh -c "reqstool report-asciidoc local -p ./test -o ./output/report_example.adoc"
+```


### PR DESCRIPTION
This adds a usage example for using the Docker image and elevated permissions in order to push to GHCR. 