### PR TITLE
feat: Fix svc requirements and set type to python in reqstool_config

### DIFF
--- a/docs/reqstool/reqstool_config.yml
+++ b/docs/reqstool/reqstool_config.yml
@@ -1,6 +1,6 @@
 # yaml-language-server: $schema=https://raw.githubusercontent.com/Luftfartsverket/reqstool-client/main/src/reqstool/resources/schemas/v1/reqstool_config.schema.json
 
-type: default
+type: python
 project_root_dir: "../.."
 locations:
   annotations: "build/reqstool/annotations.yml"

--- a/docs/reqstool/software_verification_cases.yml
+++ b/docs/reqstool/software_verification_cases.yml
@@ -187,7 +187,7 @@ cases:
     verification: automated-test
     revision: "0.4.5"
   - id: SVC_038
-    requirement_ids: ["REQ_037, REQ_038"]
+    requirement_ids: ["REQ_037", "REQ_038"]
     title: "Test to make sure that reqstool client supports predefined lifecycle states in requirements and SVCs"
     verification: automated-test
     revision: "0.4.6"


### PR DESCRIPTION
Fix requirements list assigned to a svc and changed type to `python` in reqstool_config